### PR TITLE
Add-on repository JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,28 @@
 This repository contains a Hypon cloud integration for Home Assistant.  This is provided without warranty and is for personal use only.
 
 ## Installation
-1.) Clone this repository to your local machine:
+
+### Method 1: Add-on Repository
+
+1.	In Home Assistant go to: Settings → Add-ons → Add-on store → ⋮ → Repositories
+2.	Paste this URL:
+```https://github.com/amckee23/home-assistant-hypon-cloud```
+3. Find **Hypon Cloud** under “Hypon Cloud Addon for Home Assistant” and click **Install**.
+
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Famckee23%2Fhome-assistant-hypon-cloud)
+
+### Method 2: Manual Installation
+
+1. Clone this repository to your local machine:
 git clone https://github.com/amckee23/home-assistant-hypon-cloud hypon_cloud
 cd into the hypon_cloud folder
 
-2.) from the top level of the repository run `scp -r -O hypon-cloud [user]@[ip]:/addons`
+2. from the top level of the repository run `scp -r -O hypon-cloud [user]@[ip]:/addons`
     Note:: Please ensure you have the ssh plugin installed in home assistant with sftp enabled.  Instructions can be found [here](https://community.home-assistant.io/t/home-assistant-community-add-on-ssh-web-terminal/33820)
 
-3.) Navigate in your Home Assistant frontend to **Settings** -> **Add-ons** -> **Add-on Store** -> **Select 3 button menu** -> **Check for updates** 
+3. Navigate in your Home Assistant frontend to **Settings** -> **Add-ons** -> **Add-on Store** -> **Select 3 button menu** -> **Check for updates** 
 
-4.) Install the Hypon Cloud Addon. Ensuring the following configuration is set:
+4. Install the Hypon Cloud Addon. Ensuring the following configuration is set:
     - `username` - Your Hypon Cloud username
     - `password` - Your Hypon Cloud password
     - `system_id` - The system ID of the Hypon device you wish to control (this can be found in the Hypon Cloud dashboard)

--- a/repository.json
+++ b/repository.json
@@ -1,0 +1,5 @@
+{
+  "name": "Hypon Cloud Addon for Home Assistant",
+  "url": "https://github.com/amckee23/home-assistant-hypon-cloud",
+  "maintainer": "amckee23"
+}


### PR DESCRIPTION
This PR introduces support for installing the Hypon Cloud Home Assistant add-on directly from the Add-on Store, without requiring manual scp or file transfer.

## What was changed
	•	Added a repository.json file to make this repository compatible as an add-on repository.
	•	Updated the README.md to clearly document two installation methods:

## Why

Previously, users had to manually clone the repository and copy it into /addons via SSH/SFTP. With this change, the add-on can now be added as a repository in Home Assistant and installed with just a few clicks.

## How to test
	1.	Open Home Assistant → Settings → Add-ons → Add-on store → ⋮ → Repositories
	2.	Add the following repository URL (fork for testing): ```https://github.com/JakubMazur/home-assistant-hypon-cloud```
	3.	Alternatively, click the badge below to add it directly (my fork):
[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FJakubMazur%2Fhome-assistant-hypon-cloud)
	4.	Once the repository is added, you should see Hypon Cloud listed in the Add-on Store under Local add-ons.
