### PR TITLE
Fix Dockerfile BUILD_FROM blank base image error

### DIFF
--- a/hypon-cloud/Dockerfile
+++ b/hypon-cloud/Dockerfile
@@ -1,5 +1,4 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/aarch64-base:latest
 
 RUN apk add --no-cache mosquitto-clients
 


### PR DESCRIPTION
Resolves #19

When installing this add-on via the Home Assistant add-on store on newer versions of HA OS (tested on 18.0) with Docker 29.5.3, the build fails with the following error:

ERROR: failed to build: failed to solve: base name ($BUILD_FROM) should not be blank

This occurs because the BUILD_FROM argument is not being passed through by the Supervisor during the local build process, leaving $BUILD_FROM empty when Docker attempts to resolve the base image.

The fix replaces the ARG/FROM pattern with a hardcoded base image reference:

FROM ghcr.io/home-assistant/aarch64-base:latest

This resolves the build error and the add-on installs and runs successfully.